### PR TITLE
Fix select and delete custom properties

### DIFF
--- a/src/r0tools_simple_toolbox/__init__.py
+++ b/src/r0tools_simple_toolbox/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "r0Tools - Simple Toolbox",
     "author": "Artur Rosário",
-    "version": (0, 0, 15),
+    "version": (0, 0, 16),
     "blender": (4, 2, 0),
     "location": "3D View > Tool",
     "description": "Miscellaneous Utilities",

--- a/src/r0tools_simple_toolbox/blender_manifest.toml
+++ b/src/r0tools_simple_toolbox/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "r0tools_simple_toolbox"
-version = "0.0.15"
+version = "0.0.16"
 name = "r0Tools - Simple Toolbox"
 tagline = "General workflow utitlies"
 maintainer = "https://github.com/r0fld4nc3"

--- a/src/r0tools_simple_toolbox/operators.py
+++ b/src/r0tools_simple_toolbox/operators.py
@@ -542,6 +542,9 @@ class SimpleToolbox_OT_ClearCustomProperties(bpy.types.Operator):
                         total_objects += 1
         
         total_deletions = len(object_data_property_deletions) + len(mesh_data_property_deletions)
+
+        # Trigger property list update
+        u.continuous_property_list_update(bpy.context.scene, context, force_run=True)
         
         # u.show_notification(f"Deleted {total_deletions} propertie(s) across {total_objects} object(s)")
         self.report({'INFO'}, f"Deleted {total_deletions} propertie(s) across {total_objects} object(s)")


### PR DESCRIPTION
- Fix for ( #5 )
  -  Restore selection checking in `continuous_property_list_update` method.
  - Make use of force_run.
  - Ensure running is not triggered by simply having selected objects but instead by checking for a selection change or forcing an update. This prevents running and resetting the selection when selecting items in the List.
  - Force trigger an update in `SimpleToolbox_OT_ClearCustomProperties` Operator, to ensure the UI is then updated after the deletion takes place