### PR TITLE
0.0.26 integration

### DIFF
--- a/src/r0tools_simple_toolbox/__init__.py
+++ b/src/r0tools_simple_toolbox/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "(DEV) r0Tools - Simple Toolbox",
     "author": "Artur Rosário",
-    "version": (0, 0, 25),
+    "version": (0, 0, 26),
     "blender": (4, 2, 0),
     "location": "3D View > Tool",
     "description": "Miscellaneous Utilities",

--- a/src/r0tools_simple_toolbox/__init__.py
+++ b/src/r0tools_simple_toolbox/__init__.py
@@ -1,5 +1,5 @@
 bl_info = {
-    "name": "r0Tools - Simple Toolbox",
+    "name": "(DEV) r0Tools - Simple Toolbox",
     "author": "Artur Rosário",
     "version": (0, 0, 25),
     "blender": (4, 2, 0),

--- a/src/r0tools_simple_toolbox/blender_manifest.toml
+++ b/src/r0tools_simple_toolbox/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "r0tools_simple_toolbox"
-version = "0.0.25"
+version = "0.0.26"
 name = "r0Tools - Simple Toolbox"
 tagline = "General workflow utitlies"
 maintainer = "https://github.com/r0fld4nc3"

--- a/src/r0tools_simple_toolbox/defines.py
+++ b/src/r0tools_simple_toolbox/defines.py
@@ -25,12 +25,13 @@ def _set_addon_internal_name(from_name: str):
 
 
 # fmt: off
-DEBUG           = False
-VERSION         = bl_info.get("version", (0, 0, 0))
-VERSION_STR     = _version_str(VERSION)
-BASE_NAME       = "r0tools_simple_toolbox"
-ADDON_NAME      = bl_info.get("name")
-INTERNAL_NAME   = _set_addon_internal_name(BASE_NAME)
-REPO_NAME       = "r0Tools Extensions"
-UPDATE_CHECK_CD = 60  # seconds
+DEBUG              = False
+VERSION            = bl_info.get("version", (0, 0, 0))
+VERSION_STR        = _version_str(VERSION)
+BASE_NAME          = "r0tools_simple_toolbox"
+ADDON_NAME         = bl_info.get("name")
+INTERNAL_NAME      = _set_addon_internal_name(BASE_NAME)
+REPO_NAME          = "r0Tools Extensions"
+UPDATE_CHECK_CD    = 60  # seconds
+TOOLBOX_PROPS_NAME = "r0fl_toolbox_props"
 # fmt: on

--- a/src/r0tools_simple_toolbox/depsgraph.py
+++ b/src/r0tools_simple_toolbox/depsgraph.py
@@ -14,27 +14,9 @@ def handler_depsgraph_post_update(scene, depsgraph):
     CustomTransformsOrientationsTracker.track_custom_orientations(scene)
 
 
-@bpy.app.handlers.persistent
-def refresh_object_sets_colours(context):
-    """Refresh colors for all object sets"""
-    if u.IS_DEBUG():
-        print("[DEPSGRAPH] Force Refreshing Object Sets' Colours")
-    addon_prefs = u.get_addon_prefs()
-    addon_props = u.get_addon_props()
-    object_sets = addon_props.object_sets
-
-    if not addon_prefs.object_sets_use_colour:
-        return
-
-    for object_set in object_sets:
-        if u.IS_DEBUG():
-            print(f"[DEBUG] [DEPSGRAPH] Refresh: {object_set.name}")
-        object_set.update_object_set_colour(context)
-
-
 depsgraph_handlers = [handler_depsgraph_post_update]
 
-load_post_handlers = [refresh_object_sets_colours]
+load_post_handlers = [u.refresh_object_sets_colours]
 
 
 def register():

--- a/src/r0tools_simple_toolbox/menus.py
+++ b/src/r0tools_simple_toolbox/menus.py
@@ -2,12 +2,17 @@ import bpy
 
 
 class SimpleToolbox_MT_ObjectSetsActionsMenu(bpy.types.Menu):
+    bl_idname = "r0tools.object_sets_actions_menu"
     bl_label = "Object Sets Actions"
 
     def draw(self, context):
-        from .operators import SimpleToolbox_OT_RenameObjectsInObjectSet
+        from .operators import (
+            SimpleToolbox_OT_ForceRefreshObjectSets,
+            SimpleToolbox_OT_RenameObjectsInObjectSet,
+        )
 
         layout = self.layout
+        layout.operator(SimpleToolbox_OT_ForceRefreshObjectSets.bl_idname, icon="FILE_REFRESH")
         layout.operator(SimpleToolbox_OT_RenameObjectsInObjectSet.bl_idname, icon="OUTLINER_OB_FONT")
 
 

--- a/src/r0tools_simple_toolbox/operators.py
+++ b/src/r0tools_simple_toolbox/operators.py
@@ -1232,16 +1232,20 @@ class SimpleToolbox_OT_RandomiseObjectSetsColours(bpy.types.Operator):
 
     bl_label = "Randomise"
     bl_idname = "r0tools.object_sets_colours_randomise"
-    bl_description = "Randomise the colour of each Object Set, respecting the existing colours (if any) and without overlapping colours.\n- SHIFT: Force randomise all colours."
+    bl_description = "Randomise the colour of each Object Set, respecting the existing colours (if any) and without overlapping colours\n- SHIFT: Force randomise all Object Sets' colours\n- CTRL: Force randomise active Object Set colour"
     bl_options = {"INTERNAL", "UNDO_GROUPED"}
 
     override = False
+    override_active = False
 
     def invoke(self, context, event):
         self.override = False  # Always reset
+        self.override_active = False  # Always reset
 
         if event.shift:
             self.override = True
+        if not event.shift and event.ctrl:
+            self.override_active = True
 
         return self.execute(context)
 
@@ -1255,8 +1259,17 @@ class SimpleToolbox_OT_RandomiseObjectSetsColours(bpy.types.Operator):
             set_colour = [c for c in object_set.set_colour]
 
             if set_colour != default_set_colour:
-                if not self.override:
+                if not self.override and not self.override_active:
                     continue
+
+                # We are overriding curent
+                if self.override_active:
+                    object_set_name = object_set.name
+                    if not object_set_name == get_object_set_name_at_index(get_active_object_set_index()):
+                        # Skip if the names don't match, meaning it's not the active set
+                        continue
+                    else:
+                        print(f"[OPERATORS] Force updating active Object Set colour.")
 
             for _ in range(10):  # While loops can go wrong. Range is more controlled. Boom!
                 new_colour = (

--- a/src/r0tools_simple_toolbox/operators.py
+++ b/src/r0tools_simple_toolbox/operators.py
@@ -738,7 +738,6 @@ class SimpleToolbox_OT_FindModifierSearch(bpy.types.Operator):
         search_text_split = [s.strip() for s in search_text.split(",")]
 
         view_layer_objs = bpy.context.view_layer.objects
-        scene_objects = bpy.context.scene.objects
 
         if u.IS_DEBUG():
             print(f"[DEBUG] {search_text=}")

--- a/src/r0tools_simple_toolbox/operators.py
+++ b/src/r0tools_simple_toolbox/operators.py
@@ -1210,7 +1210,7 @@ class SimpleToolbox_OT_SelectObjectSet(bpy.types.Operator):
 class SimpleToolbox_OT_ForceRefreshObjectSets(bpy.types.Operator):
     """Force run update count which should help refresh some Object Sets properties"""
 
-    bl_label = "Refresh"
+    bl_label = "Force Refresh Sets Colours"
     bl_idname = "r0tools.object_sets_refresh"
     bl_description = "Force refresh and update Object Sets' colours"
     bl_options = {"INTERNAL"}

--- a/src/r0tools_simple_toolbox/properties.py
+++ b/src/r0tools_simple_toolbox/properties.py
@@ -372,7 +372,7 @@ class r0SimpleToolboxProps(bpy.types.PropertyGroup):
     )
 
     show_custom_property_list_prop: BoolProperty(  # type: ignore
-        name="Delete Custom Properties",
+        name="Custom Properties",
         description="List Custom Properties",
         default=False,
     )

--- a/src/r0tools_simple_toolbox/properties.py
+++ b/src/r0tools_simple_toolbox/properties.py
@@ -135,17 +135,20 @@ class R0PROP_ObjectSetEntryItem(bpy.types.PropertyGroup):
             if o.object == obj:
                 # Revert object colour back to default white
                 self.objects.remove(i)
-                # Check if object not in other sets
-                containing_sets = self.check_object_in_sets(obj)
-                if not containing_sets:
-                    obj.color = (1.0, 1.0, 1.0, 1.0)
-                else:
-                    # Update the object to another set's colour
-                    if allow_override:
-                        obj.color = containing_sets[-1].set_colour
-                    else:
-                        obj.color = containing_sets[0].set_colour
                 break
+
+        # Check if object still exists:
+        if u.is_valid_object_global(obj):
+            # Check if object not in other sets
+            containing_sets = self.check_object_in_sets(obj)
+            if not containing_sets:
+                obj.color = (1.0, 1.0, 1.0, 1.0)
+            else:
+                # Update the object to another set's colour
+                if allow_override:
+                    obj.color = containing_sets[-1].set_colour
+                else:
+                    obj.color = containing_sets[0].set_colour
 
         self.update_count()
 

--- a/src/r0tools_simple_toolbox/properties.py
+++ b/src/r0tools_simple_toolbox/properties.py
@@ -389,8 +389,8 @@ class r0SimpleToolboxProps(bpy.types.PropertyGroup):
     )
     object_sets: CollectionProperty(type=R0PROP_ObjectSetEntryItem)  # type: ignore
     object_sets_index: IntProperty(default=0)  # type: ignore
-    data_objects: CollectionProperty(type=R0PROP_ObjectSetObjectItem)  # type: ignore
-    scene_objects: CollectionProperty(type=R0PROP_ObjectSetObjectItem)  # type: ignore
+    # data_objects: CollectionProperty(type=R0PROP_ObjectSetObjectItem)  # type: ignore
+    # scene_objects: CollectionProperty(type=R0PROP_ObjectSetObjectItem)  # type: ignore
     objects_updated: BoolProperty(default=False)  # type: ignore
 
     show_find_modifier_search: BoolProperty(  # type: ignore

--- a/src/r0tools_simple_toolbox/ui.py
+++ b/src/r0tools_simple_toolbox/ui.py
@@ -96,9 +96,9 @@ class r0Tools_PT_SimpleToolbox(bpy.types.Panel):
             row = custom_properties_box.row()
             row.prop(addon_props, "show_custom_property_list_prop", icon="TRIA_DOWN" if addon_props.show_custom_property_list_prop else "TRIA_RIGHT", emboss=False)
             if addon_props.show_custom_property_list_prop:
-                row = custom_properties_box.row()
+                # row = custom_properties_box.row()
                 # Row Number Slider (Same as in addon preferences)
-                row.prop(addon_prefs, "custom_properties_list_rows", text="Rows:")
+                # row.prop(addon_prefs, "custom_properties_list_rows", text="Rows:")
                 
                 row = custom_properties_box.row()
                 row.template_list(

--- a/src/r0tools_simple_toolbox/utils/general.py
+++ b/src/r0tools_simple_toolbox/utils/general.py
@@ -2,7 +2,7 @@ import math
 
 import bpy
 
-from ..defines import DEBUG
+from ..defines import DEBUG, TOOLBOX_PROPS_NAME
 from ..utils import (
     CUSTOM_PROPERTIES_TYPES,
     OBJECT_MODES,
@@ -427,6 +427,12 @@ def property_list_update(scene, context, force_run=False):
     This function updates the custom property list panel
     when object selection changes.
     """
+
+    # Potential fix for "AttributeError: Writing to ID classes in this context is now allowed: Scene, Scene datablock"
+    if not hasattr(scene, TOOLBOX_PROPS_NAME):
+        print(f"[INFO] [GENERAL] Scene does not have proper attribute. Skipping.")
+        return
+
     addon_props = get_addon_props()
 
     if not addon_props.show_custom_property_list_prop and not force_run:
@@ -510,9 +516,11 @@ def property_list_update(scene, context, force_run=False):
             context_error_debug(error=e)
 
         # Force UI update
-        for area in bpy.context.screen.areas:
-            if area.type in {"PROPERTIES", "OUTLINER", "VIEW_3D"}:
-                area.tag_redraw()
+        if bpy.context.screen:
+            if hasattr(bpy.context.screen, "areas"):
+                for area in bpy.context.screen.areas:
+                    if area.type in {"PROPERTIES", "OUTLINER", "VIEW_3D"}:
+                        area.tag_redraw()
 
     return None
 

--- a/src/r0tools_simple_toolbox/utils/general.py
+++ b/src/r0tools_simple_toolbox/utils/general.py
@@ -184,27 +184,21 @@ def is_valid_object_global(obj):
     Check if an object reference is valid
     """
     try:
-        exists_object = (
-            obj is not None
-            and obj
-            and obj.name in bpy.data.objects
-            and any(obj.name in scene.objects for scene in bpy.data.scenes)
-        )
-
-        if not exists_object:
-            if IS_DEBUG():
-                if obj is not None:
-                    print(f"[DEBUG] [GENERAL] Dangling reference: {obj.name}")
-                else:
-                    print(f"[DEBUG] [GENERAL] Dangling reference: {obj}")
+        if not obj:
             return False
 
-        return True
-    except ReferenceError:
-        print(f"ReferenceError when checking object validity")
+        # Direct data check
+        data_objects = bpy.data.objects
+        if obj.name not in data_objects:
+            return False
+
+        # Has the object been orphaned?
+        return any(data_objects[obj.name].users_scene)
+    except (ReferenceError, KeyError):
         return False
     except Exception as e:
-        print(f"Error checking object validity: {e}")
+        if IS_DEBUG():
+            print(f"[ERROR] [GENERAL] Validation error: {e}")
         return False
 
 

--- a/src/r0tools_simple_toolbox/utils/object_sets.py
+++ b/src/r0tools_simple_toolbox/utils/object_sets.py
@@ -146,8 +146,8 @@ def draw_objects_sets_uilist(layout, context, object_sets_box=None):
     row.prop(addon_prefs, "object_sets_use_colour")
 
     # Object Sets Row Number Slider (Same as in addon preferences)
-    row = parent.row()
-    row.prop(addon_prefs, "object_sets_list_rows", text="Rows:")
+    # row = parent.row()
+    # row.prop(addon_prefs, "object_sets_list_rows", text="Rows:")
 
     row = parent.row()
     split = row.split(factor=0.92)  # Affects right side button width

--- a/src/r0tools_simple_toolbox/utils/object_sets.py
+++ b/src/r0tools_simple_toolbox/utils/object_sets.py
@@ -224,7 +224,7 @@ def cleanup_object_set_invalid_references(scene):
                 invalid_objects.append(obj)
 
         cleaned_up = 0
-        for obj in invalid_objects:
+        for obj in reversed(invalid_objects):
             try:
                 object_set.remove_object(obj)
                 cleaned_up += 1
@@ -235,11 +235,10 @@ def cleanup_object_set_invalid_references(scene):
             print(f"Cleaned up {cleaned_up} references for Object Set '{object_set.name}'")
 
     # Force UI Update to reflect changes
-    if bpy.context.screen:
-        if hasattr(bpy.context.screen, "areas"):
-            for area in bpy.context.screen.areas:
-                if area.type in {"PROPERTIES", "OUTLINER", "VIEW_3D"}:
-                    area.tag_redraw()
+    for window in bpy.context.window_manager.windows:
+        for area in window.screen.areas:
+            if area.type in {"PROPERTIES", "OUTLINER", "VIEW_3D"}:
+                area.tag_redraw()
 
 
 @bpy.app.handlers.persistent

--- a/src/r0tools_simple_toolbox/utils/object_sets.py
+++ b/src/r0tools_simple_toolbox/utils/object_sets.py
@@ -116,6 +116,18 @@ def draw_objects_sets_uilist(layout, context, object_sets_box=None):
         context: The current context
         object_sets_box: Optional box to draw within
     """
+    from ..menus import SimpleToolbox_MT_ObjectSetsActionsMenu
+    from ..operators import (
+        SimpleToolbox_OT_AddObjectSetPopup,
+        SimpleToolbox_OT_AddToObjectSet,
+        SimpleToolbox_OT_MoveObjectSetItemDown,
+        SimpleToolbox_OT_MoveObjectSetItemUp,
+        SimpleToolbox_OT_RandomiseObjectSetsColours,
+        SimpleToolbox_OT_RemoveFromObjectSet,
+        SimpleToolbox_OT_RemoveObjectSet,
+        SimpleToolbox_OT_SelectObjectSet,
+    )
+
     addon_prefs = u.get_addon_prefs()
     addon_props = u.get_addon_props()
 
@@ -153,22 +165,19 @@ def draw_objects_sets_uilist(layout, context, object_sets_box=None):
 
     # Right side - Buttons
     col = split.column(align=True)
-    col.operator("r0tools.add_object_set_popup", text="+")
-    col.operator("r0tools.remove_object_set", text="-")
+    col.operator(SimpleToolbox_OT_AddObjectSetPopup.bl_idname, text="+")
+    col.operator(SimpleToolbox_OT_RemoveObjectSet.bl_idname, text="-")
     if len(addon_props.object_sets) > 1:  # Show buttons only when applicable
         col.separator(factor=1.0)  # Spacer
-        col.operator("r0tools.move_object_set_item_up", icon="TRIA_UP", text="")
-        col.operator("r0tools.move_object_set_item_down", icon="TRIA_DOWN", text="")
+        col.operator(SimpleToolbox_OT_MoveObjectSetItemUp.bl_idname, icon="TRIA_UP", text="")
+        col.operator(SimpleToolbox_OT_MoveObjectSetItemDown.bl_idname, icon="TRIA_DOWN", text="")
 
     col.separator(factor=1.0)  # Spacer
-    col.operator("r0tools.object_sets_refresh", text="", icon="FILE_REFRESH")
+    col.operator(SimpleToolbox_OT_RandomiseObjectSetsColours.bl_idname, text="", icon="NODE_MATERIAL")
 
+    # Object Sets Actions (Downward arrow dropdown menu)
     col.separator(factor=1.0)  # Spacer
-    col.operator("r0tools.object_sets_colours_randomise", text="", icon="NODE_MATERIAL")
-
-    # Object Sets Actions (Downward arrow HLT dropdown menu)
-    col.separator(factor=1.0)  # Spacer
-    col.menu("SimpleToolbox_MT_ObjectSetsActionsMenu", text="")
+    col.menu(SimpleToolbox_MT_ObjectSetsActionsMenu.bl_idname, text="")
 
     # Bottom
     if object_sets_box:
@@ -180,11 +189,11 @@ def draw_objects_sets_uilist(layout, context, object_sets_box=None):
     # Add/Remove Object Set Buttons
     split = row.split(factor=0.65)
     row_col = split.row(align=True)
-    row_col.operator("r0tools.assign_to_object_set")
-    row_col.operator("r0tools.remove_from_object_set")
+    row_col.operator(SimpleToolbox_OT_AddToObjectSet.bl_idname)
+    row_col.operator(SimpleToolbox_OT_RemoveFromObjectSet.bl_idname)
     # Select Object Set Button
     row_col = split.row()
-    op = row_col.operator("r0tools.select_object_set")
+    op = row_col.operator(SimpleToolbox_OT_SelectObjectSet.bl_idname)
     op.set_index = -1
 
 


### PR DESCRIPTION
* Further attempt to fix `AttributeError: Writing to ID classes in this context is not allowed: Scene, Scene datablock, error setting r0SimpleToolboxProps.<UNKNOWN>`
* Moved Operator "Randomise Object Sets Colours" to Object Sets Action Menu
* Added new CTRL override action to "Randomise Object Sets Colours", to force randomise the colour of the active (selected) Object Set.
* Updated description of Randomise Object Sets Colours description.
* Updated text of section "Delete Custom Properties" to "Custom Properties".